### PR TITLE
NEO-107 Criar plugin para calcular as métricas de propriedades do bloco

### DIFF
--- a/PerformanceCheck/BlockHelper.cs
+++ b/PerformanceCheck/BlockHelper.cs
@@ -4,10 +4,8 @@ using Neo.Persistence;
 
 namespace Neo.Plugins
 {
-    internal static class Helper
+    internal static class BlockHelper
     {
-        #region BlockHelper
-
         /// <summary>
         /// Returns the time the given block was active
         /// </summary>
@@ -50,17 +48,16 @@ namespace Neo.Plugins
             var firstIndex = Blockchain.GenesisBlock.Index;
             var blockHash = snapshot.CurrentBlockHash;
 
-            var countedBlocks = 0;
+            var countedBlocks = -1;
             Block block = snapshot.GetBlock(blockHash);
-            ulong totaltime = block.GetTime();
+            ulong totaltime = 0;
 
-            block = snapshot.GetBlock(block.PrevHash);
-            while (block != null && block.Index != firstIndex && desiredCount > countedBlocks)
+            do
             {
                 totaltime += block.GetTime();
                 block = snapshot.GetBlock(block.PrevHash);
                 countedBlocks++;
-            }
+            } while (block != null && block.Index != firstIndex && desiredCount > countedBlocks);
 
             double averageTime = 0.0;
             if (countedBlocks > 0)
@@ -70,7 +67,5 @@ namespace Neo.Plugins
 
             return averageTime;
         }
-
-        #endregion
     }
 }

--- a/PerformanceCheck/Helper.cs
+++ b/PerformanceCheck/Helper.cs
@@ -1,0 +1,76 @@
+﻿using Neo.Ledger;
+using Neo.Network.P2P.Payloads;
+using Neo.Persistence;
+
+namespace Neo.Plugins
+{
+    internal static class Helper
+    {
+        #region BlockHelper
+
+        /// <summary>
+        /// Returns the time the given block was active
+        /// </summary>
+        /// <param name="block">
+        /// The given block to verify the time
+        /// </param>
+        /// <returns>
+        /// Returns 0 if <code>block</code> is the current block or is the genesis block or is null;
+        /// otherwise, returns the time the block was active in milliseconds
+        /// </returns>
+        public static ulong GetTime(this Block block)
+        {
+            ulong time = 0;
+
+            if (block != null && block.Index > 0 && block.Index < Blockchain.Singleton.Height)
+            {
+                var nextBlock = Blockchain.Singleton.GetBlock(block.Index + 1);
+
+                if (nextBlock != null)
+                {
+                    time = nextBlock.Timestamp - block.Timestamp;
+                }
+            }
+
+            return time;
+        }
+
+        /// <summary>
+        /// Returns the average time the latest blocks are active
+        /// </summary>
+        /// <param name="desiredCount">
+        /// The desired number of blocks that should be checked to calculate the average time
+        /// </param>
+        /// <returns>
+        /// Returns the average time per block in milliseconds if the number of analysed blocks
+        /// is greater than zero; otherwise, returns 0.0
+        /// </returns>
+        public static double GetAverageTimePerBlock(this SnapshotView snapshot, uint desiredCount)
+        {
+            var firstIndex = Blockchain.GenesisBlock.Index;
+            var blockHash = snapshot.CurrentBlockHash;
+
+            var countedBlocks = 0;
+            Block block = snapshot.GetBlock(blockHash);
+            ulong totaltime = block.GetTime();
+
+            block = snapshot.GetBlock(block.PrevHash);
+            while (block != null && block.Index != firstIndex && desiredCount > countedBlocks)
+            {
+                totaltime += block.GetTime();
+                block = snapshot.GetBlock(block.PrevHash);
+                countedBlocks++;
+            }
+
+            double averageTime = 0.0;
+            if (countedBlocks > 0)
+            {
+                averageTime = 1.0 * totaltime / countedBlocks;
+            }
+
+            return averageTime;
+        }
+
+        #endregion
+    }
+}

--- a/PerformanceCheck/PerformanceCheck.cs
+++ b/PerformanceCheck/PerformanceCheck.cs
@@ -1,0 +1,190 @@
+using Neo.Ledger;
+using Neo.Network.P2P.Payloads;
+using System;
+
+namespace Neo.Plugins
+{
+    public class PerformanceCheck : Plugin
+    {
+        public override string Name => "PerformanceCheck";
+
+        protected override void Configure()
+        {
+            Settings.Load(GetConfiguration());
+        }
+
+        protected override bool OnMessage(object message)
+        {
+            if (!(message is string[] args)) return false;
+            if (args.Length == 0) return false;
+            switch (args[0].ToLower())
+            {
+                case "help":
+                    return OnHelpCommand(args);
+                case "block":
+                    return OnBlockCommand(args);
+            }
+            return false;
+        }
+
+        /// <summary>
+        /// Process "help" command
+        /// </summary>
+        /// <param name="args"></param>
+        /// <returns></returns>
+        private bool OnHelpCommand(string[] args)
+        {
+            if (args.Length < 2)
+                return false;
+
+            if (!string.Equals(args[1], Name, StringComparison.OrdinalIgnoreCase))
+                return false;
+
+            Console.WriteLine($"{Name} Commands:\n");
+            Console.WriteLine("Block Commands:");
+            Console.WriteLine("\tblock time <index/hash>");
+            Console.WriteLine("\tblock avgtime [2 - 10000]");
+
+            return true;
+        }
+
+        /// <summary>
+        /// Process "block" command
+        /// </summary>
+        /// <param name="args"></param>
+        /// <returns></returns>
+        private bool OnBlockCommand(string[] args)
+        {
+            if (args.Length < 2) return false;
+            switch (args[1].ToLower())
+            {
+                case "avgtime":
+                case "averagetime":
+                    return OnBlockAverageTimeCommand(args);
+                case "time":
+                    return OnBlockTimeCommand(args);
+                default:
+                    return false;
+            }
+        }
+
+        /// <summary>
+        /// Calculates and prints the average time the latest blocks are active
+        /// </summary>
+        /// <param name="args"></param>
+        /// <returns></returns>
+        private bool OnBlockAverageTimeCommand(string[] args)
+        {
+            if (args.Length > 3)
+            {
+                return false;
+            }
+            else
+            {
+                uint desiredCount;
+                if (args.Length == 3)
+                {
+                    desiredCount = uint.Parse(args[2]);
+                    if (desiredCount < 2)
+                    {
+                        Console.WriteLine("Minimum 2 block");
+                        return true;
+                    }
+                    if (desiredCount > 10000)
+                    {
+                        Console.WriteLine("Maximum 10000 blocks");
+                        return true;
+                    }
+                }
+                else
+                {
+                    desiredCount = 1000;
+                }
+
+                var firstIndex = Blockchain.GenesisBlock.Index;
+                using (var snapshot = Blockchain.Singleton.GetSnapshot())
+                {
+                    var blockHash = snapshot.CurrentBlockHash;
+                    var countedBlocks = 0;
+                    ulong totaltime = 0;
+                    Block block = snapshot.GetBlock(blockHash);
+
+                    ulong nextTimestamp = block.Timestamp;
+                    block = snapshot.GetBlock(block.PrevHash);
+
+                    while (block != null && block.Index != firstIndex && desiredCount > countedBlocks)
+                    {
+                        totaltime += nextTimestamp - block.Timestamp;
+                        nextTimestamp = block.Timestamp;
+
+                        block = snapshot.GetBlock(block.PrevHash);
+                        countedBlocks++;
+                    }
+
+                    double averageInSeconds;
+                    if (countedBlocks > 0)
+                    {
+                        var timeInSeconds = totaltime / 1000.0;
+                        averageInSeconds = timeInSeconds / countedBlocks;
+                    }
+                    else
+                    {
+                        averageInSeconds = 0.0;
+                    }
+
+                    Console.WriteLine(averageInSeconds.ToString("Average time/block: 0.00 seconds"));
+                }
+                return true;
+            }
+        }
+
+        /// <summary>
+        /// Calculates and prints the block time of the given block index or block hash
+        /// </summary>
+        /// <param name="args"></param>
+        /// <returns></returns>
+        private bool OnBlockTimeCommand(string[] args)
+        {
+            if (args.Length != 3)
+            {
+                return false;
+            }
+            else
+            {
+                string blockId = args[2];
+                Block block;
+
+                if (blockId.Length == 66)
+                {
+                    var blockHash = UInt256.Parse(blockId);
+                    block = Blockchain.Singleton.GetBlock(blockHash);
+                }
+                else
+                {
+                    var blockIndex = uint.Parse(blockId);
+                    block = Blockchain.Singleton.GetBlock(blockIndex);
+                }
+
+                if (block != null)
+                {
+                    var previousBlock = Blockchain.Singleton.GetBlock(block.PrevHash);
+                    ulong time = 0;
+                    if (previousBlock != null)
+                    {
+                        time = block.Timestamp - previousBlock.Timestamp;
+                    }
+
+                    Console.WriteLine($"Block Hash: {block.Hash}");
+                    Console.WriteLine($"      Index: {block.Index}");
+                    Console.WriteLine($"      Time: {time / 1000}");
+                }
+                else
+                {
+                    Console.WriteLine("Block not found");
+                }
+
+                return true;
+            }
+        }
+    }
+}

--- a/PerformanceCheck/PerformanceCheck.csproj
+++ b/PerformanceCheck/PerformanceCheck.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <Version>3.0.0-CI00817</Version>
+    <TargetFramework>netstandard2.1</TargetFramework>
+    <RootNamespace>Neo.Plugins</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Update="PerformanceCheck\config.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+    </None>
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Neo" Version="3.0.0-CI00817" />
+  </ItemGroup>
+
+</Project>

--- a/PerformanceCheck/PerformanceCheck/config.json
+++ b/PerformanceCheck/PerformanceCheck/config.json
@@ -1,0 +1,5 @@
+{
+  "PluginConfiguration": {
+    "Path": "PerformanceCheck_{0}"
+  }
+}

--- a/PerformanceCheck/Settings.cs
+++ b/PerformanceCheck/Settings.cs
@@ -1,0 +1,21 @@
+using Microsoft.Extensions.Configuration;
+
+namespace Neo.Plugins
+{
+    internal class Settings
+    {
+        public string Path { get; }
+
+        public static Settings Default { get; private set; }
+
+        private Settings(IConfigurationSection section)
+        {
+            this.Path = string.Format(section.GetSection("Path").Value ?? "PerformanceCheck_{0}", ProtocolSettings.Default.Magic.ToString("X8"));
+        }
+
+        public static void Load(IConfigurationSection section)
+        {
+            Default = new Settings(section);
+        }
+    }
+}

--- a/neo-plugins.sln
+++ b/neo-plugins.sln
@@ -17,6 +17,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "RpcNep5Tracker", "RpcNep5Tr
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CoreMetrics", "CoreMetrics\CoreMetrics.csproj", "{AEFFF003-3500-416B-AD9B-8C838C33C1F4}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PerformanceCheck", "PerformanceCheck\PerformanceCheck.csproj", "{69F53F21-0900-4843-AD52-D923DD649443}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -51,6 +53,10 @@ Global
 		{AEFFF003-3500-416B-AD9B-8C838C33C1F4}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{AEFFF003-3500-416B-AD9B-8C838C33C1F4}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{AEFFF003-3500-416B-AD9B-8C838C33C1F4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{69F53F21-0900-4843-AD52-D923DD649443}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{69F53F21-0900-4843-AD52-D923DD649443}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{69F53F21-0900-4843-AD52-D923DD649443}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{69F53F21-0900-4843-AD52-D923DD649443}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
``block time <index|hash>``
Exibe o tempo que o bloco permaneceu ativo. O bloco pode ser identificado pelo índice ou pelo hash
![image](https://user-images.githubusercontent.com/19419485/73099640-a6bde480-3eca-11ea-9fff-a05e3b50a6bd.png)
![image](https://user-images.githubusercontent.com/19419485/73099657-b3423d00-3eca-11ea-8ddd-b0807b55cd31.png)

``block avgtime [1 - 10000]``
Exibe o tempo médio que os n blocos mais recentes permaneceram ativos.
![image](https://user-images.githubusercontent.com/19419485/73099726-d2d96580-3eca-11ea-9bd9-0e0685ab4081.png)
![image](https://user-images.githubusercontent.com/19419485/73099759-e4227200-3eca-11ea-9833-c595743201ac.png)
