### PR TITLE
NEO-108 Criar plugin para calcular as métricas do algoritmo de consenso

### DIFF
--- a/PerformanceCheck/PerformanceCheck.cs
+++ b/PerformanceCheck/PerformanceCheck.cs
@@ -864,13 +864,13 @@ namespace Neo.Plugins
         }
 
         /// <summary>
-        /// Calculates the time difference between the persist and the commit
+        /// Calculates the time difference between the commit request and the actual commit
         /// </summary>
         /// <param name="printMessages">
         /// Specifies if the messages should be printed in the console.
         /// </param>
         /// <returns>
-        /// Returns the difference between the persist time and the commit time
+        /// Returns the difference between the commit request time and the actual commit time
         /// </returns>
         private double GetTimeToConfirm(bool printMessages = false)
         {
@@ -944,7 +944,7 @@ namespace Neo.Plugins
 
         /// <summary>
         /// Process "payload time" command
-        /// Prints the time in milliseconds to confirm the block
+        /// Prints the time in milliseconds to receive a payload
         /// </summary>
         private bool OnPayloadTimeCommand()
         {

--- a/PerformanceCheck/PerformanceCheck.cs
+++ b/PerformanceCheck/PerformanceCheck.cs
@@ -1,4 +1,5 @@
 using Akka.Actor;
+using Neo.Consensus;
 using Neo.Ledger;
 using Neo.Network.P2P;
 using Neo.Network.P2P.Payloads;
@@ -28,12 +29,29 @@ namespace Neo.Plugins
             OnCommitEvent?.Invoke(snapshot);
         }
 
+        private delegate void PersistHandler(StoreView snapshot, IReadOnlyList<Blockchain.ApplicationExecuted> applicationExecutedList);
+        private event PersistHandler OnPersistEvent;
+
+        public void OnPersist(StoreView snapshot, IReadOnlyList<Blockchain.ApplicationExecuted> applicationExecutedList)
+        {
+            OnPersistEvent?.Invoke(snapshot, applicationExecutedList);
+        }
+
         private delegate void P2PMessageHandler(Message message);
         private event P2PMessageHandler OnP2PMessageEvent;
 
         public bool OnP2PMessage(Message message)
         {
             OnP2PMessageEvent?.Invoke(message);
+            return true;
+        }
+
+        private delegate void ConsensusMessageHandler(ConsensusPayload payload);
+        private event ConsensusMessageHandler OnConsensusMessageEvent;
+
+        public bool OnConsensusMessage(ConsensusPayload payload)
+        {
+            OnConsensusMessageEvent?.Invoke(payload);
             return true;
         }
 
@@ -52,6 +70,13 @@ namespace Neo.Plugins
                     return OnTransactionCommand(args);
                 case "check":
                     return OnCheckCommand(args);
+                case "commit":
+                    return OnCommitCommand(args);
+                case "confirm":
+                case "confirmation":
+                    return OnConfirmationCommand(args);
+                case "payload":
+                    return OnPayloadCommand(args);
             }
             return false;
         }
@@ -77,6 +102,10 @@ namespace Neo.Plugins
             Console.WriteLine("\tcheck cpu");
             Console.WriteLine("\tcheck memory");
             Console.WriteLine("\tcheck threads");
+            Console.WriteLine("Consensus Commands:");
+            Console.WriteLine("\tcommit time");
+            Console.WriteLine("\tconfirmation time");
+            Console.WriteLine("\tpayload time");
             Console.WriteLine("Transaction Commands:");
             Console.WriteLine("\ttx size <hash>");
             Console.WriteLine("\ttx avgsize [1 - 10000]");
@@ -207,7 +236,7 @@ namespace Neo.Plugins
                 var delayInMilliseconds = GetBlockSynchronizationDelay(true);
                 if (delayInMilliseconds <= 0)
                 {
-                    Console.WriteLine("The time to confirm that a new block has timed out.");
+                    Console.WriteLine("The time to confirm a new block has timed out.");
                 }
                 else if (delayInMilliseconds < 1000)
                 {
@@ -705,6 +734,325 @@ namespace Neo.Plugins
             cancel.Cancel();
 
             return true;
+        }
+
+        /// <summary>
+        /// Process "check" command
+        /// </summary>
+        private bool OnCommitCommand(string[] args)
+        {
+            if (args.Length < 2) return false;
+            switch (args[1].ToLower())
+            {
+                case "time":
+                    return OnCommitTimeCommand();
+                default:
+                    return false;
+            }
+        }
+
+        /// <summary>
+        /// Process "commit time" command
+        /// Prints the time in milliseconds to commit in the network
+        /// </summary>
+        private bool OnCommitTimeCommand()
+        {
+            var time = GetTimeToCommit(true);
+            if (time > 0)
+            {
+                Console.WriteLine($"Time to commit: {time:0.##} milliseconds");
+            }
+            else
+            {
+                Console.WriteLine("Timeout");
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        /// Calculates the time difference between the persist and the commit
+        /// </summary>
+        /// <param name="printMessages">
+        /// Specifies if the messages should be printed in the console.
+        /// </param>
+        /// <returns>
+        /// Returns the difference between the persist time and the commit time
+        /// </returns>
+        private double GetTimeToCommit(bool printMessages = false)
+        {
+            var commit = new TaskCompletionSource<bool>();
+            var persist = new TaskCompletionSource<bool>();
+
+            DateTime persistTime = DateTime.Now;
+            DateTime commitTime = persistTime;
+
+            CommitHandler commitAction = (store) =>
+            {
+                commitTime = DateTime.Now;
+                commit?.TrySetResult(true);
+            };
+            PersistHandler persistAction = (store, app) =>
+            {
+                persistTime = DateTime.Now;
+                persist?.TrySetResult(true);
+            };
+
+            OnCommitEvent += commitAction;
+            OnPersistEvent += persistAction;
+
+            if (printMessages)
+            {
+                Console.WriteLine("Waiting for the next commit...");
+            }
+
+            List<Task> tasks = new List<Task>
+            {
+                commit.Task,
+                persist.Task
+            };
+
+            var millisecondsToTimeOut = (int)Blockchain.MillisecondsPerBlock;
+            Task.WaitAll(tasks.ToArray(), millisecondsToTimeOut);
+
+            OnCommitEvent -= commitAction;
+            OnPersistEvent -= persistAction;
+
+            if (!tasks.TrueForAll(task => !task.IsCanceled))
+            {
+                return 0;
+            }
+
+            var timeToCommit = persistTime - commitTime;
+
+            return Math.Abs(timeToCommit.TotalMilliseconds);
+        }
+
+        /// <summary>
+        /// Process "confirmation" command
+        /// </summary>
+        private bool OnConfirmationCommand(string[] args)
+        {
+            if (args.Length < 2) return false;
+            switch (args[1].ToLower())
+            {
+                case "time":
+                    return OnConfirmationTimeCommand();
+                default:
+                    return false;
+            }
+        }
+
+        /// <summary>
+        /// Process "confirmation time" command
+        /// Prints the time in milliseconds to confirm the block
+        /// </summary>
+        private bool OnConfirmationTimeCommand()
+        {
+            var time = GetTimeToConfirm(true);
+
+            if (time > 0)
+            {
+                Console.WriteLine($"Confirmation Time: {time:0.##} milliseconds");
+            }
+            else
+            {
+                Console.WriteLine("Timeout");
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        /// Calculates the time difference between the persist and the commit
+        /// </summary>
+        /// <param name="printMessages">
+        /// Specifies if the messages should be printed in the console.
+        /// </param>
+        /// <returns>
+        /// Returns the difference between the persist time and the commit time
+        /// </returns>
+        private double GetTimeToConfirm(bool printMessages = false)
+        {
+            var commit = new TaskCompletionSource<bool>(false);
+            var consensusMessage = new TaskCompletionSource<bool>(false);
+
+            DateTime consensusMessageTime = DateTime.Now;
+            DateTime commitTime = DateTime.Now;
+
+            CommitHandler commitAction = (store) =>
+            {
+                commitTime = DateTime.Now;
+                commit?.TrySetResult(true);
+            };
+            ConsensusMessageHandler consensusMessageAction = (payload) =>
+            {
+                if (payload.ConsensusMessage is Commit)
+                {
+                    consensusMessageTime = DateTime.Now;
+                    consensusMessage?.TrySetResult(true);
+                }
+            };
+
+            OnCommitEvent += commitAction;
+            OnConsensusMessageEvent += consensusMessageAction;
+
+            if (printMessages)
+            {
+                Console.WriteLine("Waiting for the next commit...");
+            }
+
+            List<Task<bool>> tasks = new List<Task<bool>>
+            {
+                commit.Task,
+                consensusMessage.Task
+            };
+
+            var millisecondsToTimeOut = (int)Blockchain.MillisecondsPerBlock;
+            Task.WaitAll(tasks.ToArray(), millisecondsToTimeOut);
+
+            OnCommitEvent -= commitAction;
+            OnConsensusMessageEvent -= consensusMessageAction;
+
+            foreach (Task<bool> task in tasks)
+            {
+                if (!task.IsCompleted)
+                {
+                    return 0;
+                }
+            }
+
+            var timeToConfirm = commitTime - consensusMessageTime;
+
+            return Math.Abs(timeToConfirm.TotalMilliseconds);
+        }
+
+        /// <summary>
+        /// Process "payload" command
+        /// </summary>
+        private bool OnPayloadCommand(string[] args)
+        {
+            if (args.Length < 2) return false;
+            switch (args[1].ToLower())
+            {
+                case "time":
+                    return OnPayloadTimeCommand();
+                default:
+                    return false;
+            }
+        }
+
+        /// <summary>
+        /// Process "payload time" command
+        /// Prints the time in milliseconds to confirm the block
+        /// </summary>
+        private bool OnPayloadTimeCommand()
+        {
+            var time = GetPayloadTime(true);
+            if (time > 0)
+            {
+                Console.WriteLine($"Payload Time: {time:0.##} milliseconds");
+            }
+            else
+            {
+                Console.WriteLine("Timeout");
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        /// Calculates the time difference between the payload send and receive time
+        /// </summary>
+        /// <param name="printMessages">
+        /// Specifies if the messages should be printed in the console.
+        /// </param>
+        /// <returns>
+        /// Returns the difference between the payload send time and receive time
+        /// </returns>
+        private double GetPayloadTime(bool printMessages = false)
+        {
+            var consensusMessage = new TaskCompletionSource<bool>();
+
+            DateTime consensusMessageTime = DateTime.Now;
+            DateTime consensusPayloadTime = consensusMessageTime;
+
+            ConsensusMessageHandler consensusMessageAction = (payload) =>
+            {
+                var timestamp = GetPayloadTimestamp(payload);
+                if (timestamp > ulong.MinValue)
+                {
+                    consensusMessageTime = DateTime.UtcNow;
+                    consensusPayloadTime = TimestampToDateTime(timestamp);
+                    consensusMessage?.TrySetResult(true);
+                }
+            };
+
+            OnConsensusMessageEvent += consensusMessageAction;
+
+            if (printMessages)
+            {
+                Console.WriteLine("Waiting for the next payload...");
+            }
+            var millisecondsToTimeOut = (int)Blockchain.MillisecondsPerBlock;
+            consensusMessage.Task.Wait(millisecondsToTimeOut);
+
+            OnConsensusMessageEvent -= consensusMessageAction;
+
+            if (!consensusMessage.Task.IsCompleted)
+            {
+                return 0;
+            }
+
+            var timeToConfirm = consensusMessageTime - consensusPayloadTime;
+            return Math.Abs(timeToConfirm.TotalMilliseconds);
+        }
+
+        /// <summary>
+        /// Gets the timestamp from a consensus payload
+        /// </summary>
+        /// <param name="payload">
+        /// The payload to get the timestamp
+        /// </param>
+        /// <returns>
+        /// Returns the timestamp of the <paramref name="payload"/> if it has the Timestamp property;
+        /// otherwise, returns 0.
+        /// </returns>
+        private ulong GetPayloadTimestamp(ConsensusPayload payload)
+        {
+            switch (payload.ConsensusMessage)
+            {
+                case ChangeView view:
+                    return view.Timestamp;
+                case PrepareRequest request:
+                    return request.Timestamp;
+                case RecoveryRequest request:
+                    return request.Timestamp;
+                default:
+                    return ulong.MinValue;
+            }
+        }
+
+        /// <summary>
+        /// Converts a timestamp value to a <see cref="DateTime"/> object
+        /// </summary>
+        /// <param name="timestamp">
+        /// THe timestamp value in milliseconds
+        /// </param>
+        /// <returns>
+        /// If the result is a valid <see cref="DateTime"/>, returns the DateTime object that represents
+        /// the timestamp value; otherwise, returns the <see cref="DateTime.UnixEpoch"/>.
+        /// </returns>
+        private DateTime TimestampToDateTime(ulong timestamp)
+        {
+            try
+            {
+                return DateTime.UnixEpoch.AddMilliseconds(timestamp);
+            }
+            catch (ArgumentOutOfRangeException)
+            {
+                return DateTime.UnixEpoch;
+            }
         }
     }
 }

--- a/PerformanceCheck/PerformanceCheck.csproj
+++ b/PerformanceCheck/PerformanceCheck.csproj
@@ -15,7 +15,7 @@
 
   <ItemGroup>
     <PackageReference Include="System.Diagnostics.PerformanceCounter" Version="4.7.0" />
-    <PackageReference Include="Neo" Version="3.0.0-CI00817" />
+    <PackageReference Include="Neo" Version="3.0.0-CI00855" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
`commit time`
Exibe o tempo em milissegundos entre a proposta e o commit de um bloco.
![image](https://user-images.githubusercontent.com/19419485/75383411-0c7f0100-58bb-11ea-8c9e-99d1bd5b53f4.png)

`confirmation time`
Exibe o tempo em milissegundos entre a requisição de um commit e a confirmação do commit.
Esse comando só exibe o resultado se o nó for um nó de consenso.
![image](https://user-images.githubusercontent.com/19419485/75383391-038e2f80-58bb-11ea-9c78-e89dd83fecad.png)

`payload time`
Exibe o tempo em milissegundos entre a emissão e o recebimento de um payload.
Esse comando só exibe o resultado se o nó for um nó de consenso.
![image](https://user-images.githubusercontent.com/19419485/75383431-14d73c00-58bb-11ea-928e-59d0898aff20.png)