### PR TITLE
NEO-106 Criar plugin para calcular as métricas de protocolo de rede

### DIFF
--- a/PerformanceCheck/PerformanceCheck.cs
+++ b/PerformanceCheck/PerformanceCheck.cs
@@ -3,10 +3,13 @@ using Neo.Consensus;
 using Neo.Ledger;
 using Neo.Network.P2P;
 using Neo.Network.P2P.Payloads;
+using Neo.Network.RPC;
 using Neo.Persistence;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Net;
+using System.Net.NetworkInformation;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -75,8 +78,16 @@ namespace Neo.Plugins
                 case "confirm":
                 case "confirmation":
                     return OnConfirmationCommand(args);
+                case "connected":
+                case "connectednodes":
+                    return OnNetworkConnectedNodesCommand();
+                case "ping":
+                case "pingpeers":
+                    return OnNetworkPingPeersCommand(args);
                 case "payload":
                     return OnPayloadCommand(args);
+                case "rpc":
+                    return OnRpcCommand(args);
             }
             return false;
         }
@@ -96,6 +107,7 @@ namespace Neo.Plugins
             Console.WriteLine("Block Commands:");
             Console.WriteLine("\tblock time <index/hash>");
             Console.WriteLine("\tblock avgtime [1 - 10000]");
+            Console.WriteLine("\tblock timesincelast");
             Console.WriteLine("\tblock sync");
             Console.WriteLine("Check Commands:");
             Console.WriteLine("\tcheck disk");
@@ -106,6 +118,10 @@ namespace Neo.Plugins
             Console.WriteLine("\tcommit time");
             Console.WriteLine("\tconfirmation time");
             Console.WriteLine("\tpayload time");
+            Console.WriteLine("Network Commands:");
+            Console.WriteLine("\tconnected");
+            Console.WriteLine("\tping [ipaddress]");
+            Console.WriteLine("\trpc time <url>");
             Console.WriteLine("Transaction Commands:");
             Console.WriteLine("\ttx size <hash>");
             Console.WriteLine("\ttx avgsize [1 - 10000]");
@@ -129,6 +145,10 @@ namespace Neo.Plugins
                 case "sync":
                 case "synchronization":
                     return OnBlockSynchronizationCommand();
+                case "sincelast":
+                case "timelast":
+                case "timesincelast":
+                    return OnBlockTimeSinceLastCommand();
                 default:
                     return false;
             }
@@ -217,6 +237,32 @@ namespace Neo.Plugins
 
                 return true;
             }
+        }
+
+        /// <summary>
+        /// Prints the time passed in seconds since the last block
+        /// </summary>
+        private bool OnBlockTimeSinceLastCommand()
+        {
+            var timeSinceLastBlockInSec = GetTimeSinceLastBlock() / 1000;
+            Console.WriteLine($"Time since last block: {timeSinceLastBlockInSec} seconds");
+
+            return true;
+        }
+
+        /// <summary>
+        /// Calculates the time passed since the last block
+        /// </summary>
+        /// <returns>
+        /// Returns the time since the last block was persisted in milliseconds
+        /// </returns>
+        private ulong GetTimeSinceLastBlock()
+        {
+            var index = Blockchain.Singleton.Height;
+            var block = Blockchain.Singleton.GetBlock(index);
+
+            var currentTimestamp = (ulong)DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+            return currentTimestamp - block.Timestamp;
         }
 
         /// <summary>
@@ -1053,6 +1099,280 @@ namespace Neo.Plugins
             {
                 return DateTime.UnixEpoch;
             }
+        }
+
+        /// <summary>
+        /// Prints the number of nodes connected to the local node
+        /// </summary>
+        private bool OnNetworkConnectedNodesCommand()
+        {
+            Console.WriteLine($"Connected nodes: {LocalNode.Singleton.ConnectedCount}");
+            foreach (RemoteNode node in LocalNode.Singleton.GetRemoteNodes())
+            {
+                Console.WriteLine($"  ip: {node.Remote.Address,-15}\theight: {node.LastBlockIndex,-8}");
+            }
+            return true;
+        }
+
+        /// <summary>
+        /// Send a ping message to the node specified by its IP address.
+        /// If none is specified, send a ping message to each peer connected to the local node
+        /// </summary>
+        private bool OnNetworkPingPeersCommand(string[] args)
+        {
+            if (args.Length > 2)
+            {
+                return false;
+            }
+            else
+            {
+                if (args.Length == 2)
+                {
+                    if (args[1] == null || !IPAddress.TryParse(args[1], out var ipaddress))
+                    {
+                        Console.WriteLine("Invalid parameter");
+                        return true;
+                    }
+
+                    PingRemoteNode(ipaddress, true);
+                }
+                else
+                {
+                    PingAll(true);
+                }
+
+                return true;
+            }
+        }
+
+        /// <summary>
+        /// Sends a ping message to the IP addresses of all connected and unconnected peers
+        /// </summary>
+        /// <param name="printMessages">
+        /// Specifies if the messages should be printed in the console.
+        /// </param>
+        private void PingAll(bool printMessages = false)
+        {
+            var tasks = new List<Task>();
+            if (printMessages)
+            {
+                Console.WriteLine($"Connected nodes: {LocalNode.Singleton.ConnectedCount}\tUnconnected nodes: {LocalNode.Singleton.UnconnectedCount}");
+            }
+
+            // ping remote nodes
+            foreach (RemoteNode node in LocalNode.Singleton.GetRemoteNodes())
+            {
+                Task ping = new Task(() =>
+                {
+                    var reply = TryPing(node.Remote.Address);
+                    if (printMessages && reply != null)
+                    {
+                        if (reply.Status == IPStatus.Success)
+                        {
+                            Console.WriteLine($"  {node.Remote.Address,-15}\t{reply.RoundtripTime,-30:###0 ms}\theight: {node.LastBlockIndex,-7}");
+                        }
+                        else
+                        {
+                            Console.WriteLine($"  {node.Remote.Address,-15}\t{reply.Status,-30}\theight: {node.LastBlockIndex,-7}");
+                        }
+                    }
+                });
+                tasks.Add(ping);
+                ping.Start();
+            }
+
+            // ping unconnected peers
+            foreach (var node in LocalNode.Singleton.GetUnconnectedPeers())
+            {
+                Task ping = new Task(() =>
+                {
+                    var reply = TryPing(node.Address);
+                    if (printMessages && reply != null)
+                    {
+                        if (reply.Status == IPStatus.Success)
+                        {
+                            Console.WriteLine($"  {node.Address,-15}\t{reply.RoundtripTime,-30:###0 ms}\tunconnected");
+                        }
+                        else
+                        {
+                            Console.WriteLine($"  {node.Address,-15}\t{reply.Status,-30}\tunconnected");
+                        }
+                    }
+                });
+                tasks.Add(ping);
+                ping.Start();
+            }
+
+            Task.WaitAll(tasks.ToArray());
+        }
+
+        /// <summary>
+        /// Sends a ping message to specified IP address if it is the address of a remote node
+        /// </summary>
+        /// <param name="printMessages">
+        /// Specifies if the messages should be printed in the console.
+        /// </param>
+        private void PingRemoteNode(IPAddress ipaddress, bool printMessages = false)
+        {
+            var remoteNode = GetRemoteNode(ipaddress);
+            if (remoteNode == null)
+            {
+                if (printMessages)
+                {
+                    Console.WriteLine("Input address was not a connected peer");
+                }
+                return;
+            }
+
+            var reply = TryPing(ipaddress);
+            if (printMessages && reply != null)
+            {
+                if (reply.Status == IPStatus.Success)
+                {
+                    Console.WriteLine($"  {ipaddress,-15}\t{reply.RoundtripTime,-30:###0 ms}\theight: {remoteNode.LastBlockIndex,-7}");
+                }
+                else
+                {
+                    Console.WriteLine($"  {ipaddress,-15}\t{reply.Status,-30}\theight: {remoteNode.LastBlockIndex,-7}");
+                }
+            }
+        }
+
+        /// <summary>
+        /// Verifies if a given IP address is the address of a remote node.
+        /// </summary>
+        /// <param name="ipaddress">
+        /// The IP address to be verified.
+        /// </param>
+        /// <returns>
+        /// If the <paramref name="ipaddress"/> is the address of a remote node, returns the
+        /// corresponding remote node; otherwise, returns null.
+        /// </returns>
+        private RemoteNode GetRemoteNode(IPAddress ipaddress)
+        {
+            foreach (RemoteNode node in LocalNode.Singleton.GetRemoteNodes())
+            {
+                if (node.Remote.Address.Equals(ipaddress))
+                {
+                    return node;
+                }
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Tries to send a ping message to the specified IP address.
+        /// </summary>
+        /// <param name="ipaddress">
+        /// The IP address to send the ping message.
+        /// </param>
+        /// <returns>
+        /// Returns null if an exception is thrown; otherwise returns the <see cref="PingReply"/>
+        /// object that is the response of ping
+        /// </returns>
+        private PingReply TryPing(IPAddress ipaddress)
+        {
+            try
+            {
+                int timeoutInMs = 10000; // ping timeout is 10 seconds
+
+                Ping ping = new Ping();
+                var reply = ping.Send(ipaddress, timeoutInMs);
+
+                return reply;
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// Process "rpc" command
+        /// </summary>
+        private bool OnRpcCommand(string[] args)
+        {
+            if (args.Length < 2) return false;
+            switch (args[1].ToLower())
+            {
+                case "time":
+                    return OnRpcTimeCommand(args);
+                default:
+                    return false;
+            }
+        }
+
+        /// <summary>
+        /// Process "rpc time" command
+        /// Prints the time in milliseconds to receive the response of a rpc request
+        /// </summary>
+        private bool OnRpcTimeCommand(string[] args)
+        {
+            if (args.Length != 3)
+            {
+                return false;
+            }
+            else
+            {
+                var url = args[2];
+
+                if (!Uri.TryCreate(url, UriKind.Absolute, out var uri))
+                {
+                    Console.WriteLine("Input url is invalid");
+                    return true;
+                }
+
+                var responseTime = GetRpcResponseTime(url);
+
+                if (responseTime > 0)
+                {
+                    Console.WriteLine($"RPC response time: {responseTime:0.##} milliseconds");
+                }
+
+                return true;
+            }
+        }
+
+        /// <summary>
+        /// Gets the time to receive the response of a rpc request
+        /// </summary>
+        /// <param name="url">
+        /// The url of the rpc server
+        /// </param>
+        /// <returns>
+        /// Returns zero if any exception is thrown; otherwise, returns the time in milliseconds of
+        /// the response from the rpc request
+        /// </returns>
+        private long GetRpcResponseTime(string url)
+        {
+            Console.WriteLine($"Sending a RPC request to '{url}'...");
+            bool hasThrownException = false;
+
+            RpcClient client = new RpcClient(url);
+            Stopwatch watch = Stopwatch.StartNew();
+
+            try
+            {
+                client.GetBlockCount();
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine(
+                    "An exception was thrown while trying to send the RPC request:\n" +
+                    $"\t{e.GetType()}\n" +
+                    $"\t{e.Message}");
+                hasThrownException = true;
+            }
+
+            watch.Stop();
+
+            if (hasThrownException)
+            {
+                return 0;
+            }
+
+            return watch.ElapsedMilliseconds;
         }
     }
 }

--- a/PerformanceCheck/PerformanceCheck.csproj
+++ b/PerformanceCheck/PerformanceCheck.csproj
@@ -16,6 +16,7 @@
   <ItemGroup>
     <PackageReference Include="System.Diagnostics.PerformanceCounter" Version="4.7.0" />
     <PackageReference Include="Neo" Version="3.0.0-CI00855" />
+    <ProjectReference Include="..\RpcClient\RpcClient.csproj" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
`block timesincelast`
Exibe quantos segundos se passaram desde que o bloco mais recente foi emitido.
![image](https://user-images.githubusercontent.com/19419485/75719372-6a448c00-5cb3-11ea-86f5-b0ae55caf615.png)

`ping [ipaddress]`
Envia uma mensagem de ping para o nó especificado pelo endereço de IP. Se nenhum endereço de IP for especificado, envia uma mensagem de ping para todos os nós conectados e peers não conectados e aguarda o retorno.
![image](https://user-images.githubusercontent.com/19419485/75719820-3453d780-5cb4-11ea-8002-d99e4927241b.png)

![image](https://user-images.githubusercontent.com/19419485/75718729-3d43a980-5cb2-11ea-9eb8-b08f39d2e488.png)

`connected`
Mostra todos os nós conectados com seus respectivos endereços de IP e índice do último bloco
![image](https://user-images.githubusercontent.com/19419485/75718821-5d736880-5cb2-11ea-9aca-2135be62030b.png)

`rpc time <url>`
Exibe na tela o tempo em milissegundos para obter uma resposta de um RPC Server especificado por seu url.
![image](https://user-images.githubusercontent.com/19419485/75719552-b1cb1800-5cb3-11ea-8d0b-abf6971fd86f.png)
