### PR TITLE
NEO-140 Criar RPC para obter resultados dos plugins de métricas - métodos que já estão separados

### DIFF
--- a/src/PerformanceMonitor/CpuUsageMonitor.cs
+++ b/src/PerformanceMonitor/CpuUsageMonitor.cs
@@ -33,6 +33,8 @@ namespace Neo.Plugins
         {
             ThreadsProcessorTime = new Dictionary<int, double>();
             Watch = Stopwatch.StartNew();
+            // initialize processor time
+            CheckAllThreads();
         }
 
         /// <summary>

--- a/src/PerformanceMonitor/CpuUsageMonitor.cs
+++ b/src/PerformanceMonitor/CpuUsageMonitor.cs
@@ -4,6 +4,18 @@ using System.Diagnostics;
 
 namespace Neo.Plugins
 {
+    class CpuUsage
+    {
+        public double TotalUsage;
+        public Dictionary<int, double> ThreadsUsage;
+
+        public CpuUsage(double totalUsage, Dictionary<int, double> threadsUsage)
+        {
+            TotalUsage = totalUsage;
+            ThreadsUsage = threadsUsage;
+        }
+    }
+
     class CpuUsageMonitor
     {
         /// <summary>
@@ -32,17 +44,34 @@ namespace Neo.Plugins
         /// <returns>
         /// Total CPU usage of the threads.
         /// </returns>
-        public double CheckAllThreads(bool printEachThread = false)
+        public double GetCpuTotalProcessorTime(bool printEachThread = false)
+        {
+            var result = CheckAllThreads(printEachThread);
+            return result.TotalUsage;
+        }
+
+        /// <summary>
+        /// Checks the percentage of CPU usage of each thread of the current process.
+        /// </summary>
+        /// <param name="printEachThread">
+        /// Specifies if the CPU usage information should be printed in the console.
+        /// </param>
+        /// <returns>
+        /// An object with the total CPU usage and the CPU usage of each thread.
+        /// </returns>
+        public CpuUsage CheckAllThreads(bool printEachThread = false)
         {
             double total = 0;
             string result = "";
             var processName = Process.GetCurrentProcess().ProcessName;
             var lastProcessorTime = new Dictionary<int, double>();
+            var threadUsage = new Dictionary<int, double>();
 
             foreach (ProcessThread thread in Process.GetCurrentProcess().Threads)
             {
                 var cpuUsage = CheckCPUThread(thread, out var newTime);
                 lastProcessorTime.Add(thread.Id, newTime);
+                threadUsage.Add(thread.Id, cpuUsage);
 
                 result += $"{processName,10}/{thread.Id,-8}\t      CPU usage: {cpuUsage,8:0.00 %}\n";
                 total += cpuUsage;
@@ -57,7 +86,7 @@ namespace Neo.Plugins
                 Console.Write(result);
             }
 
-            return total;
+            return new CpuUsage(total, threadUsage);
         }
 
         /// <summary>

--- a/src/PerformanceMonitor/PerformanceMonitor.BlockProperties.cs
+++ b/src/PerformanceMonitor/PerformanceMonitor.BlockProperties.cs
@@ -1,7 +1,9 @@
 using Neo.ConsoleService;
+using Neo.IO.Json;
 using Neo.Ledger;
 using Neo.Network.P2P.Payloads;
 using System;
+using System.Text;
 
 namespace Neo.Plugins
 {
@@ -14,17 +16,7 @@ namespace Neo.Plugins
         [ConsoleCommand("block time", Category = "Block Commands", Description = "Show the block time in seconds of the given block index or block hash.")]
         private void OnBlockTimeCommand(string blockIndexOrHash)
         {
-            Block block = null;
-
-            if (UInt256.TryParse(blockIndexOrHash, out var blockHash))
-            {
-                block = Blockchain.Singleton.GetBlock(blockHash);
-            }
-            else if (uint.TryParse(blockIndexOrHash, out var blockIndex))
-            {
-                block = Blockchain.Singleton.GetBlock(blockIndex);
-            }
-
+            Block block = GetBlock(blockIndexOrHash);
             if (block == null)
             {
                 Console.WriteLine("Block not found");
@@ -37,6 +29,53 @@ namespace Neo.Plugins
                 Console.WriteLine($"      Index: {block.Index}");
                 Console.WriteLine($"      Time: {time / 1000.0: 0.00} seconds");
             }
+        }
+
+        /// <summary>
+        /// Gets the block time in seconds of the given block index or block hash
+        /// </summary>
+        /// Returns the block if the index or hash exists
+        /// </returns>
+        [RpcMethod]
+        public JObject GetBlockTime(JArray _params)
+        {
+            if (_params.Count != 1)
+            {
+                throw new RpcException(-32602, "Invalid params");
+            }
+            var blockIndexOrHash = _params[0].AsString();
+            Block block = GetBlock(blockIndexOrHash);
+
+            if (block is null)
+                throw new RpcException(-100, "Block not found");
+
+            return block.GetTime();
+        }
+
+        /// <summary>
+        /// Get a block identified by its index or hash
+        /// </summary>
+        /// <param name="blockIndexOrHash">
+        /// Index or hash of the desired block
+        /// </param>
+        /// <returns>
+        /// Returns the block if the index or hash exists; otherwise,
+        /// returns null
+        /// </returns>
+        private Block GetBlock(string blockIndexOrHash)
+        {
+            Block block = null;
+
+            if (UInt256.TryParse(blockIndexOrHash, out var blockHash))
+            {
+                block = Blockchain.Singleton.GetBlock(blockHash);
+            }
+            else if (uint.TryParse(blockIndexOrHash, out var blockIndex))
+            {
+                block = Blockchain.Singleton.GetBlock(blockIndex);
+            }
+
+            return block;
         }
 
         /// <summary>
@@ -64,6 +103,44 @@ namespace Neo.Plugins
             {
                 var averageInSeconds = snapshot.GetAverageTimePerBlock(desiredCount) / 1000;
                 Console.WriteLine(averageInSeconds.ToString("Average time/block: 0.00 seconds"));
+            }
+        }
+
+        /// <summary>
+        /// Gets the average time the latest blocks are active
+        /// </summary>
+        /// <returns>
+        /// Returns the average time per block in milliseconds
+        /// </returns>
+        [RpcMethod]
+        public JObject GetBlockAvgTime(JArray _params)
+        {
+            if (_params.Count > 1)
+            {
+                throw new RpcException(-32602, "Invalid params");
+            }
+            uint desiredCount = 1000;
+            if (_params.Count > 0)
+            {
+                if (!uint.TryParse(_params[0].AsString(), out desiredCount))
+                {
+                    throw new RpcException(-32602, "Invalid params");
+                }
+
+                if (desiredCount < 1)
+                {
+                    throw new RpcException(-100, "Minimum 1 block");
+                }
+
+                if (desiredCount > 10000)
+                {
+                    throw new RpcException(-100, "Maximum 10000 blocks");
+                }
+            }
+
+            using (var snapshot = Blockchain.Singleton.GetSnapshot())
+            {
+                return snapshot.GetAverageTimePerBlock(desiredCount);
             }
         }
     }

--- a/src/PerformanceMonitor/PerformanceMonitor.Consensus.cs
+++ b/src/PerformanceMonitor/PerformanceMonitor.Consensus.cs
@@ -1,5 +1,6 @@
 using Neo.Consensus;
 using Neo.ConsoleService;
+using Neo.IO.Json;
 using Neo.Ledger;
 using Neo.Network.P2P.Payloads;
 using System;
@@ -26,6 +27,28 @@ namespace Neo.Plugins
             {
                 Console.WriteLine("Timeout");
             }
+        }
+
+        /// <summary>
+        /// Gets the time to commit in the network in milliseconds
+        /// </summary>
+        /// <returns>
+        /// Returns the difference between the persist time and the commit time
+        /// </returns>
+        [RpcMethod]
+        public JObject GetCommitTime(JArray _params)
+        {
+            if (_params.Count != 0)
+            {
+                throw new RpcException(-32602, "Invalid params");
+            }
+            var time = GetTimeToCommit();
+            if (time <= 0)
+            {
+                throw new RpcException(-100, "TimeOut");
+            }
+
+            return time;
         }
 
         /// <summary>
@@ -103,6 +126,28 @@ namespace Neo.Plugins
             {
                 Console.WriteLine("Timeout. Make sure the start consensus command has been run.");
             }
+        }
+
+        /// <summary>
+        /// Gets the time to confirm the block in milliseconds
+        /// </summary>
+        /// <returns>
+        /// Returns the difference between the commit request time and the actual commit time
+        /// </returns>
+        [RpcMethod]
+        public JObject GetConfirmTime(JArray _params)
+        {
+            if (_params.Count != 0)
+            {
+                throw new RpcException(-32602, "Invalid params");
+            }
+            var time = GetTimeToConfirm();
+            if (time <= 0)
+            {
+                throw new RpcException(-100, "TimeOut");
+            }
+
+            return time;
         }
 
         /// <summary>
@@ -185,6 +230,28 @@ namespace Neo.Plugins
             {
                 Console.WriteLine("Timeout. Make sure the start consensus command has been run.");
             }
+        }
+
+        /// <summary>
+        /// Gets the time in milliseconds to receive a payload
+        /// </summary>
+        /// <returns>
+        /// Returns the difference between the payload send time and receive time
+        /// </returns>
+        [RpcMethod]
+        public JObject GetPayloadTime(JArray _params)
+        {
+            if (_params.Count != 0)
+            {
+                throw new RpcException(-32602, "Invalid params");
+            }
+            var time = GetPayloadTime();
+            if (time <= 0)
+            {
+                throw new RpcException(-100, "TimeOut");
+            }
+
+            return time;
         }
 
         /// <summary>

--- a/src/PerformanceMonitor/PerformanceMonitor.IO.cs
+++ b/src/PerformanceMonitor/PerformanceMonitor.IO.cs
@@ -66,7 +66,7 @@ namespace Neo.Plugins
                 throw new RpcException(-100, "There are no connected nodes");
             }
 
-            var delayInMilliseconds = GetBlockSynchronizationDelay(true);
+            var delayInMilliseconds = GetBlockSynchronizationDelay();
             if (delayInMilliseconds <= 0)
             {
                 throw new RpcException(-100, "TimeOut");

--- a/src/PerformanceMonitor/PerformanceMonitor.IO.cs
+++ b/src/PerformanceMonitor/PerformanceMonitor.IO.cs
@@ -1,4 +1,5 @@
 using Neo.ConsoleService;
+using Neo.IO.Json;
 using Neo.Ledger;
 using Neo.Network.P2P;
 using Neo.Network.P2P.Payloads;
@@ -42,6 +43,36 @@ namespace Neo.Plugins
                     Console.WriteLine($"Time to synchronize to the last remote block: {delayInSeconds:0.#} sec");
                 }
             }
+        }
+
+        /// <summary>
+        /// Gets the delay in the synchronization of the blocks between the
+        /// connected nodes
+        /// </summary>
+        /// <returns>
+        /// Returns the delay in the synchronization between the local and
+        /// the remote nodes in milliseconds
+        /// </returns>
+        [RpcMethod]
+        public JObject GetBlockSyncTime(JArray _params)
+        {
+            if (_params.Count != 0)
+            {
+                throw new RpcException(-32602, "Invalid params");
+            }
+            var lastBlockRemote = GetMaxRemoteBlockCount();
+            if (lastBlockRemote <= 0)
+            {
+                throw new RpcException(-100, "There are no connected nodes");
+            }
+
+            var delayInMilliseconds = GetBlockSynchronizationDelay(true);
+            if (delayInMilliseconds <= 0)
+            {
+                throw new RpcException(-100, "TimeOut");
+            }
+
+            return delayInMilliseconds;
         }
 
         /// <summary>
@@ -316,8 +347,46 @@ namespace Neo.Plugins
                 return;
             }
 
-            var averageInKbytes = GetSizePerTransaction(desiredCount);
-            Console.WriteLine(averageInKbytes.ToString("Average size/tx: 0 bytes"));
+            var averageInBytes = GetSizePerTransaction(desiredCount);
+            Console.WriteLine(averageInBytes.ToString("Average size/tx: 0 bytes"));
+        }
+
+        /// <summary>
+        /// Gets the average size of the latest transactions in bytes
+        /// </summary>
+        /// <returns>
+        /// Returns the average size per transaction in bytes
+        /// </returns>
+        [RpcMethod]
+        public JObject GetTxAvgSize(JArray _params)
+        {
+            if (_params.Count > 1)
+            {
+                throw new RpcException(-32602, "Invalid params");
+            }
+            uint desiredCount = 1000;
+            if (_params.Count > 0)
+            {
+                if (!uint.TryParse(_params[0].AsString(), out desiredCount))
+                {
+                    throw new RpcException(-32602, "Invalid params");
+                }
+
+                if (desiredCount < 1)
+                {
+                    throw new RpcException(-100, "Minimum 1 transaction");
+                }
+
+                if (desiredCount > 10000)
+                {
+                    throw new RpcException(-100, "Maximum 10000 transaction");
+                }
+            }
+
+            using (var snapshot = Blockchain.Singleton.GetSnapshot())
+            {
+                return GetSizePerTransaction(desiredCount);
+            }
         }
 
         /// <summary>

--- a/src/PerformanceMonitor/PerformanceMonitor.NetworkProtocol.cs
+++ b/src/PerformanceMonitor/PerformanceMonitor.NetworkProtocol.cs
@@ -375,7 +375,7 @@ namespace Neo.Plugins
                 var responseTime = GetRpcResponseTime(url);
                 if (responseTime <= 0)
                 {
-                    throw new RpcException(-100, "TimeOut");
+                    throw new RpcException(-32602, "Invalid params");
                 }
 
                 return responseTime;
@@ -397,9 +397,12 @@ namespace Neo.Plugins
         /// Returns zero if any exception is thrown; otherwise, returns the time in milliseconds of
         /// the response from the rpc request
         /// </returns>
-        private long GetRpcResponseTime(string url)
+        private long GetRpcResponseTime(string url, bool printMessages = false)
         {
-            Console.WriteLine($"Sending a RPC request to '{url}'...");
+            if (printMessages)
+            {
+                Console.WriteLine($"Sending a RPC request to '{url}'...");
+            }
             bool hasThrownException = false;
 
             RpcClient client = new RpcClient(url);
@@ -411,15 +414,21 @@ namespace Neo.Plugins
             }
             catch (HttpRequestException)
             {
-                Console.WriteLine("Input url is not a the url of a valid RPC server");
+                if (printMessages)
+                {
+                    Console.WriteLine("Input url is not a the url of a valid RPC server");
+                }
                 hasThrownException = true;
             }
             catch (Exception e)
             {
-                Console.WriteLine(
-                    "An exception was thrown while trying to send the RPC request:\n" +
-                    $"\t{e.GetType()}\n" +
-                    $"\t{e.Message}");
+                if (printMessages)
+                {
+                    Console.WriteLine(
+                        "An exception was thrown while trying to send the RPC request:\n" +
+                        $"\t{e.GetType()}\n" +
+                        $"\t{e.Message}");
+                }
                 hasThrownException = true;
             }
 

--- a/src/PerformanceMonitor/PerformanceMonitor.cs
+++ b/src/PerformanceMonitor/PerformanceMonitor.cs
@@ -102,7 +102,7 @@ namespace Neo.Plugins
         /// Gets each thread CPU usage information
         /// </summary>
         /// <returns>
-        /// The total CPU usage and the CPU usage of each active thread
+        /// The total CPU usage and the CPU usage of each active thread in the last second
         /// </returns>
         [RpcMethod]
         public JObject GetCpuUsage(JArray _params)
@@ -112,15 +112,16 @@ namespace Neo.Plugins
                 throw new RpcException(-32602, "Invalid params");
             }
             var monitor = new CpuUsageMonitor();
-            // first call returns zero time
-            monitor.CheckAllThreads();
+
+            // wait a second to get the cpu usage info
+            Task.Delay(1000).Wait();
             var cpuUsage = monitor.CheckAllThreads();
 
             var result = new JObject();
             result["totalusage"] = cpuUsage.TotalUsage;
 
             var threads = new JArray();
-            foreach (var threadTime in cpuUsage.ThreadsUsage)
+            foreach (var threadTime in cpuUsage.ThreadsUsage.OrderByDescending(usage => usage.Value))
             {
                 var thread = new JObject();
                 thread["id"] = threadTime.Key;

--- a/src/PerformanceMonitor/PerformanceMonitor.cs
+++ b/src/PerformanceMonitor/PerformanceMonitor.cs
@@ -1,5 +1,6 @@
 using Akka.Actor;
 using Neo.ConsoleService;
+using Neo.IO.Json;
 using Neo.Ledger;
 using Neo.Network.P2P;
 using Neo.Network.P2P.Payloads;
@@ -7,6 +8,7 @@ using Neo.Persistence;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -15,6 +17,11 @@ namespace Neo.Plugins
     public partial class PerformanceMonitor : Plugin, IPersistencePlugin, IP2PPlugin
     {
         public override string Name => "PerformanceMonitor";
+
+        public PerformanceMonitor()
+        {
+            RpcServer.RegisterMethods(this);
+        }
 
         protected override void Configure()
         {
@@ -72,7 +79,7 @@ namespace Neo.Plugins
                 {
                     try
                     {
-                        var total = monitor.CheckAllThreads(true);
+                        var total = monitor.GetCpuTotalProcessorTime(true);
                         if (!cancel.Token.IsCancellationRequested)
                         {
                             Console.WriteLine($"Active threads: {monitor.ThreadCount,3}\tTotal CPU usage: {total,8:0.00 %}");
@@ -89,6 +96,40 @@ namespace Neo.Plugins
             });
             Console.ReadLine();
             cancel.Cancel();
+        }
+
+        /// <summary>
+        /// Gets each thread CPU usage information
+        /// </summary>
+        /// <returns>
+        /// The total CPU usage and the CPU usage of each active thread
+        /// </returns>
+        [RpcMethod]
+        public JObject GetCpuUsage(JArray _params)
+        {
+            if (_params.Count != 0)
+            {
+                throw new RpcException(-32602, "Invalid params");
+            }
+            var monitor = new CpuUsageMonitor();
+            // first call returns zero time
+            monitor.CheckAllThreads();
+            var cpuUsage = monitor.CheckAllThreads();
+
+            var result = new JObject();
+            result["totalusage"] = cpuUsage.TotalUsage;
+
+            var threads = new JArray();
+            foreach (var threadTime in cpuUsage.ThreadsUsage)
+            {
+                var thread = new JObject();
+                thread["id"] = threadTime.Key;
+                thread["usage"] = threadTime.Value;
+                threads.Add(thread);
+            }
+            result["threads"] = threads;
+
+            return result;
         }
 
         /// <summary>

--- a/src/PerformanceMonitor/PerformanceMonitor.csproj
+++ b/src/PerformanceMonitor/PerformanceMonitor.csproj
@@ -18,6 +18,7 @@
     <PackageReference Include="Neo" Version="3.0.0-CI00863" />
     <PackageReference Include="Neo.ConsoleService" Version="1.0.0" />
     <ProjectReference Include="..\RpcClient\RpcClient.csproj" />
+    <ProjectReference Include="..\RpcServer\RpcServer.csproj" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Métodos rpc criados:
- `getblocktime`, params: `blockindexorhash`
- `getblockavgtime`, params: `numblocks` (opcional)
- `getblocksynctime`
- `gettimesincelast`
- `gettxavgsize`, params: `numtxs` (opcional)
- `getcpuusage`
- `getcommittime`
- `getconfirmtime`
- `getpayloadtime`
- `getrpctime`, params: `rpcserveruri`